### PR TITLE
Add gsutil to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gsutil
 argparse
 opencv-python
 matplotlib


### PR DESCRIPTION
### Problem
- The original `download_physics_iq_data.py` did not allow the user to select an FPS outside [8, 16, 24, 30]

### Changes Made
- Refactored the `download_directory()` to allow choosing `other` as an option.
- Selecting `other` will lead to 30 FPS videos being downloaded which will later on be used to match the FPS of user provided videos.