### PR TITLE
fix address access in calculate_and_write_metrics

### DIFF
--- a/code/calculate_and_write_metrics_to_csv.py
+++ b/code/calculate_and_write_metrics_to_csv.py
@@ -93,7 +93,7 @@ def process_videos(
   scenario_data = []
   processed_scenarios = set()
   gen_video_duration_frames = get_video_frame_count(
-      os.path.join(generated_folders, sorted(os.listdir(generated_folders)[0]))
+      os.path.join(generated_folders, sorted(os.listdir(generated_folders))[0])
   )
 
   def mse_per_frame(video1, video2):
@@ -163,7 +163,7 @@ def process_videos(
   scenario_data = []
   processed_scenarios = set()
   gen_video_duration_frames = get_video_frame_count(
-      os.path.join(generated_folders, sorted(os.listdir(generated_folders)[0]))
+      os.path.join(generated_folders, sorted(os.listdir(generated_folders))[0])
   )
 
   consider_frames = fps * 5

--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -72,7 +72,6 @@ def download_physics_iq_data(fps: str):
     for directory, subdirs in directories.items():
         if subdirs:
             for fps_option in subdirs:
-                #print(directory, subdirs, fps_option)
                 remote_path = f"{base_url}/{directory}/{fps_option}FPS"
                 local_path = os.path.join(local_base_dir, directory, f"{fps_option}FPS")
                 download_directory(remote_path=remote_path, local_path=local_path)
@@ -80,7 +79,6 @@ def download_physics_iq_data(fps: str):
         else:
             remote_path = f"{base_url}/{directory}"
             local_path = os.path.join(local_base_dir, directory)
-            #print(directory)
             download_directory(remote_path=remote_path, local_path=local_path)
 
     print("Download process complete.")

--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -28,7 +28,6 @@ def download_directory(remote_path: str, local_path: str):
     Args:
       remote_path: Cloud path
       local_path: Local path
-      dry_run: If True, only prints the commands without executing them.
     """
     os.makedirs(local_path, exist_ok=True)
     print(f"Preparing to download: {remote_path} to {local_path}")
@@ -53,11 +52,13 @@ def download_physics_iq_data(fps: str):
     valid_fps = ['8', '16', '24', '30', 'other']
     assert fps in valid_fps, 'FPS needs to be in [8, 16, 24, 30, other]'
 
-    download_fps = [fps]
+    
     if fps == 'other':
         download_fps = ['30']
-    elif fps != '30':
-        download_fps.append('30')  # Always download 30FPS data
+    else:
+        download_fps = [fps]
+        if fps != '30':
+            download_fps.append('30')  # Always download 30FPS data
 
     base_url = "gs://physics-iq-benchmark"  # Base GCS URL
     local_base_dir = "./physics-IQ-benchmark"  # Local base directory
@@ -87,5 +88,5 @@ def download_physics_iq_data(fps: str):
 
 
 if __name__ == '__main__':
-    user_fps = input("Enter your model's frames per second FPS (e.g., 8, 16, 24, 30): ").strip()
+    user_fps = input("Enter your model's frames per second FPS (e.g., 8, 16, 24, 30, other): ").strip()
     download_physics_iq_data(user_fps)

--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -85,5 +85,5 @@ def download_physics_iq_data(fps: str):
 
 
 if __name__ == '__main__':
-    user_fps = input("Enter the desired FPS (e.g., 8, 16, 24, 30, other): ").strip()
+    user_fps = input("Enter your model's frames per second FPS (e.g., 8, 16, 24, 30): ").strip()
     download_physics_iq_data(user_fps)

--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -21,23 +21,48 @@ import multiprocessing
 # Ensure 'spawn' is the default start method for multiprocessing
 multiprocessing.set_start_method("spawn", force=True)
 
-def download_physics_iq_data(fps: str, dry_run: bool = False):
-    """
-    Downloads the Physics-IQ dataset based on the specified FPS.
+
+def download_directory(remote_path: str, local_path: str):
+    """Download a single directory using gsutil.
 
     Args:
-      fps: Desired FPS (e.g., '8', '16', '24', '30').
+      remote_path: Cloud path
+      local_path: Local path
       dry_run: If True, only prints the commands without executing them.
     """
+    os.makedirs(local_path, exist_ok=True)
+    print(f"Preparing to download: {remote_path} to {local_path}")
+
+    try:
+        # Limit parallel downloads to avoid freezing
+        subprocess.run(
+            ["gsutil", "-m", "-o", "GSUtil:parallel_process_count=5", "cp", "-r", remote_path + "/*", local_path], check=True
+        )
+        print(f"Downloaded: {remote_path}")
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to download: {remote_path} Error: {e}")
+        raise
+
+
+def download_physics_iq_data(fps: str):
+    """Download the Physics-IQ dataset based on the specified FPS.
+
+    Args:
+      fps: Desired FPS (in ['8', '16', '24', '30']).
+    """
     valid_fps = ['8', '16', '24', '30']
-    download_fps = [fps] if fps in valid_fps else []
-    download_fps.append('30')  # Always download 30FPS data
+    assert fps in valid_fps, 'FPS needs to be in [8, 16, 24, 30]'
+
+    download_fps = [fps]
+    if fps != '30':
+        download_fps.append('30')  # Always download 30FPS data
 
     base_url = "gs://physics-iq-benchmark"  # Base GCS URL
     local_base_dir = "./physics-IQ-benchmark"  # Local base directory
 
     directories = {
-        "full-videos": ["take-1", "take-2"],
+        "full-videos/take-1": download_fps,
+        "full-videos/take-2": download_fps,
         "split-videos/conditioning": download_fps,
         "split-videos/testing": download_fps,
         "switch-frames": None,
@@ -45,53 +70,22 @@ def download_physics_iq_data(fps: str, dry_run: bool = False):
     }
 
     for directory, subdirs in directories.items():
-        if directory == "full-videos":
-            for take in subdirs:
-                for fps_option in download_fps:
-                    remote_path = f"{base_url}/{directory}/{take}/{fps_option}FPS"
-                    local_path = os.path.join(local_base_dir, directory, take, f"{fps_option}FPS")
-                    os.makedirs(local_path, exist_ok=True)
-                    print(f"Preparing to download: {remote_path} to {local_path}")
-                    if not dry_run:
-                        try:
-                            # Limit parallel downloads to avoid freezing
-                            subprocess.run(
-                                ["gsutil", "-m", "-o", "GSUtil:parallel_process_count=5", "cp", "-r", remote_path + "/*", local_path], check=True
-                            )
-                            print(f"Downloaded: {remote_path}")
-                        except subprocess.CalledProcessError as e:
-                            print(f"Failed to download: {remote_path}. Error: {e}")
-        elif subdirs:
+        if subdirs:
             for fps_option in subdirs:
+                #print(directory, subdirs, fps_option)
                 remote_path = f"{base_url}/{directory}/{fps_option}FPS"
                 local_path = os.path.join(local_base_dir, directory, f"{fps_option}FPS")
-                os.makedirs(local_path, exist_ok=True)
-                print(f"Preparing to download: {remote_path} to {local_path}")
-                if not dry_run:
-                    try:
-                        subprocess.run(
-                            ["gsutil", "-m", "-o", "GSUtil:parallel_process_count=5", "cp", "-r", remote_path + "/*", local_path], check=True
-                        )
-                        print(f"Downloaded: {remote_path}")
-                    except subprocess.CalledProcessError as e:
-                        print(f"Failed to download: {remote_path}. Error: {e}")
+                download_directory(remote_path=remote_path, local_path=local_path)
+
         else:
             remote_path = f"{base_url}/{directory}"
             local_path = os.path.join(local_base_dir, directory)
-            os.makedirs(local_path, exist_ok=True)
-            print(f"Preparing to download: {remote_path} to {local_path}")
-            if not dry_run:
-                try:
-                    subprocess.run(
-                        ["gsutil", "-m", "-o", "GSUtil:parallel_process_count=5", "cp", "-r", remote_path + "/*", local_path], check=True
-                    )
-                    print(f"Downloaded: {remote_path}")
-                except subprocess.CalledProcessError as e:
-                    print(f"Failed to download: {remote_path}. Error: {e}")
+            #print(directory)
+            download_directory(remote_path=remote_path, local_path=local_path)
 
     print("Download process complete.")
 
 
-# Example usage
-user_fps = input("Enter the desired FPS (e.g., 8, 16, 24, 30, other): ").strip()
-download_physics_iq_data(user_fps)
+if __name__ == '__main__':
+    user_fps = input("Enter the desired FPS (e.g., 8, 16, 24, 30, other): ").strip()
+    download_physics_iq_data(user_fps)

--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -48,13 +48,15 @@ def download_physics_iq_data(fps: str):
     """Download the Physics-IQ dataset based on the specified FPS.
 
     Args:
-      fps: Desired FPS (in ['8', '16', '24', '30']).
+      fps: Desired FPS (in ['8', '16', '24', '30', 'other']).
     """
-    valid_fps = ['8', '16', '24', '30']
-    assert fps in valid_fps, 'FPS needs to be in [8, 16, 24, 30]'
+    valid_fps = ['8', '16', '24', '30', 'other']
+    assert fps in valid_fps, 'FPS needs to be in [8, 16, 24, 30, other]'
 
     download_fps = [fps]
-    if fps != '30':
+    if fps == 'other':
+        download_fps = ['30']
+    elif fps != '30':
         download_fps.append('30')  # Always download 30FPS data
 
     base_url = "gs://physics-iq-benchmark"  # Base GCS URL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gsutil
 argparse
 opencv-python
 matplotlib


### PR DESCRIPTION
Hi,

Thanks for your great work and contribution.

I find a bug for a wrong place of list's indexing in `calculate_and_write_metrics_to_csv.py`. Specifically, I think we should pick the first generated video's filename to count the frames, so we want to index the sorted list of filenames, rather than sorting the first filename's string which will cause the TypeError:

`TypeError: join() argument must be str, bytes, or os.PathLike object, not 'list'`.

I make the following changes to fix the bug, and I have successfully obtained the evaluation results.

[Original](https://github.com/google-deepmind/physics-IQ-benchmark/blob/c73f9cd64af2ba4109fba3833b670e6b89f7ce19/code/calculate_and_write_metrics_to_csv.py#L165C3-L167C4):
```
gen_video_duration_frames = get_video_frame_count(
      os.path.join(generated_folders, sorted(os.listdir(generated_folders)[0]))
  )
```

New:
```
gen_video_duration_frames = get_video_frame_count(
      os.path.join(generated_folders, sorted(os.listdir(generated_folders))[0])
  )
```

Best,

Yifu