### PR TITLE
Enable arbitrary video naming as long as ID is kept.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ python3 ./code/download_physics_iq_data.py
 ```
 
 - If your desired FPS already exists in the dataset, it will be downloaded.
-- If it does not exist, the script will download 30 FPS files and generate your desired FPS videos based on the 30 FPS version.
+- If it does not exist, the script will download 30 FPS files and generate your desired FPS videos by downsampling the 30 FPS version.
 
 ---
 
@@ -58,9 +58,9 @@ This section explains how to generate videos using the provided benchmark and sa
 
 2. **Steps to Run**:
    - Generate videos using the initial frame (and text condition, if applicable).
-   - Save generated videos in the following structure:
+   - Save generated videos in the following structure, using any filename as long as the unique ID prefix from the test videos is kept (`0001_`, ..., `0198_`):
      ```
-     .model_name/{ID}_{perspective}_{scenario_name}.mp4
+     .model_name/{ID}_{anything-you-like}.mp4
      ```
    - Refer to the `generated_video_name` column in `descriptions.csv` for file naming conventions.
 

--- a/code/calculate_and_write_metrics_to_csv.py
+++ b/code/calculate_and_write_metrics_to_csv.py
@@ -26,6 +26,7 @@ import numpy as np
 import pandas as pd
 import tqdm
 
+
 def get_video_frame_count(filepath):
   """Get the total number of frames in a video."""
   if not os.path.exists(filepath):
@@ -71,6 +72,7 @@ def process_videos(
       None: This function does not return any value but saves the results to a
       CSV file.
   """
+
   def spatial_binary_masks(mask_frames):
     """Collapse the time dimension of binary masks into a single frame."""
     if not mask_frames:
@@ -127,9 +129,8 @@ def process_videos(
     Returns:
         A list of frames from the video.
     """
-    if not os.path.exists(filepath):
-      print(f'File not found: {filepath}')
-      return []
+    assert os.path.exists(filepath), f'File not found: {filepath}'
+
     cap = cv2.VideoCapture(filepath)
     frames = []
     frame_idx = 0
@@ -199,7 +200,7 @@ def process_videos(
     Returns:
       A dictionary of calculated metrics.
     """
-    print('## Processing scenario ##: ', scenario_name)
+    print('## Processing scenario ', scenario_name)
     real_path_v1 = os.path.join(real_folders, f'{scenario_ID_take_1}_testing-videos_{fps}FPS_{view}_take-1_{scenario_name}')
     generated_path = os.path.join(
         generated_folders, f'{scenario_ID_take_1}_{view}_{scenario_name}'
@@ -281,8 +282,7 @@ def process_videos(
         or not binary_v1_frames
         or not binary_v2_frames
     ):
-      print(f'Skipping scenario {scenario_name}_{view} due to missing frames')
-      return None
+      raise ValueError(f"Scenario {scenario_name}_{view} has missing frames.")
 
     # Create subdirectories for each model in spatial and spatiotemporal maps
     # folders
@@ -393,7 +393,6 @@ def process_videos(
     }
   # Iterate over all scenarios
   # Dictionary to track processed scenarios and their IDs
-  # Dictionary to track processed scenarios and their IDs
   scenario_info = {}
   processed_scenarios = set()
   scenario_data = []
@@ -433,7 +432,7 @@ def process_videos(
       for view in ['perspective-left', 'perspective-center', 'perspective-right']:
           if view not in take_1_views or view not in take_2_views:
               raise ValueError(f"Missing IDs for scenario {scenario_name}, view {view}: "
-                              f"take-1={take_1_views.get(view)}, take-2={take_2_views.get(view)}")
+                               f"take-1={take_1_views.get(view)}, take-2={take_2_views.get(view)}")
 
       processed_scenarios.add(scenario_name)
       progress_bar.update(1)
@@ -578,5 +577,4 @@ if __name__ == '__main__':
 
   # Plot MSE values
   plot_metrics(args.csv_files, './plots', args.fps)
-
 

--- a/code/run_physics_iq.py
+++ b/code/run_physics_iq.py
@@ -151,7 +151,7 @@ def validate_generations(input_folder: str):
   files_in_folder = sorted(os.listdir(input_folder))
 
   EXPECTED_NUM_VIDEOS = 198 # number of generated videos that need to be evaluated
-  EXPECTED_VIDEO_DURATION = 5
+  EXPECTED_VIDEO_DURATION = 5 # required duration in seconds for generated videos
 
   length_error_msg = f"found {len(files_in_folder)} videos but expected {EXPECTED_NUM_VIDEOS}"
   assert len(files_in_folder) == EXPECTED_NUM_VIDEOS, length_error_msg

--- a/code/run_physics_iq.py
+++ b/code/run_physics_iq.py
@@ -74,7 +74,7 @@ def rename_generated_videos(generated_video_directory: str, real_video_directory
     name_mapping[realfile[:prefix_length]] = "_".join([
           parts[0],  # Keep the first part (e.g., 0092)
           parts[3],  # Keep the perspective (e.g., perspective-center)
-          parts[5]   # Keep the trimmed-lit-candle (e.g., trimmed-lit-candle.mp4)
+          parts[5]   # Keep the scenario name (e.g., trimmed-lit-candle.mp4)
       ])
 
   for genfile in sorted(os.listdir(generated_video_directory)):

--- a/code/run_physics_iq.py
+++ b/code/run_physics_iq.py
@@ -18,6 +18,7 @@ import sys
 import pandas as pd
 import cv2
 import argparse
+
 from fps_changer import change_video_fps
 from calculate_and_write_metrics_to_csv import process_videos
 from calculate_iq_score import process_directory
@@ -56,6 +57,35 @@ def is_csv_complete(csv_file_path: str, expected_scenarios: set[str]) -> bool:
     return True
 
 
+def rename_generated_videos(generated_video_directory: str, real_video_directory: str) -> None:
+  """Renames .mp4 files in the given directory for consistency.
+
+  Args:
+    generated_video_directory: The directory containing the generated .mp4 files.
+    real_video_directory: The directory containing the corresponding real .mp4 files.
+  """
+
+  validate_generations(generated_video_directory)
+
+  name_mapping = {}
+  prefix_length = 4
+  for realfile in sorted(os.listdir(real_video_directory)):
+    parts = realfile.split("_")
+    name_mapping[realfile[:prefix_length]] = "_".join([
+          parts[0],  # Keep the first part (e.g., 0092)
+          parts[3],  # Keep the perspective (e.g., perspective-center)
+          parts[5]   # Keep the trimmed-lit-candle (e.g., trimmed-lit-candle.mp4)
+      ])
+
+  for genfile in sorted(os.listdir(generated_video_directory)):
+    if genfile.endswith(".mp4"):
+      new_filename = name_mapping[genfile[:prefix_length]]
+      old_path = os.path.join(generated_video_directory, genfile)
+      new_path = os.path.join(generated_video_directory, new_filename)
+      os.rename(old_path, new_path)
+    else:
+      raise ValueError("Only .mp4 files are supported.")
+
 
 def validate_directory_exists(directory: str, description: str) -> None:
   """
@@ -70,6 +100,7 @@ def validate_directory_exists(directory: str, description: str) -> None:
   """
   if not os.path.exists(directory):
     raise FileNotFoundError(f"{description} not found: {directory}")
+
 
 def validate_folder_files_exist(
     folder: str, expected_files: set[str], description: str
@@ -98,6 +129,26 @@ def validate_folder_files_exist(
     )
 
   print(f"{description} folder is valid with all required files.")
+
+
+def validate_generations(input_folder: str):
+  """Check that 198 videos exist, each with an ID prefix from 0001_ to 0198_."""
+
+  assert os.path.exists(input_folder)
+  assert os.path.isdir(input_folder)
+
+  files_in_folder = sorted(os.listdir(input_folder))
+
+  EXPECTED_NUM_VIDEOS = 198 # number of generated videos that need to be evaluated
+  length_error_msg = f"found {len(files_in_folder)} videos but expected {EXPECTED_NUM_VIDEOS}"
+  assert len(files_in_folder) == EXPECTED_NUM_VIDEOS, length_error_msg
+
+  counter = 1
+  for f in files_in_folder:
+    expected_prefix = "{:04d}_".format(counter)
+    assert f.startswith(expected_prefix), "Video {f} does not start with expected video ID {expected_prefix}"
+    counter += 1
+
 
 def validate_video_files(
     input_folder: str, descriptions_file: str, video_type: str, fps: int, include_take_2: bool = False
@@ -161,6 +212,7 @@ def validate_video_files(
   print(f"Validation successful for {input_folder}.")
   return expected_files
 
+
 def get_video_fps(input_folder: str) -> float:
   """
   Gets the FPS of videos in the input folder and ensures they are
@@ -194,6 +246,7 @@ def get_video_fps(input_folder: str) -> float:
   fps = fps_values.pop()
   print(f"All videos in {input_folder} have FPS: {fps}")
   return fps
+
 
 def ensure_real_videos_at_fps(
     output_folder: str, target_fps: float, descriptions_file: str
@@ -237,6 +290,7 @@ def ensure_real_videos_at_fps(
   print(f"Real videos at FPS {int(target_fps)} are ready at {target_fps_folder}.")
   return target_fps_folder
 
+
 def ensure_binary_mask_structure(
     output_folder: str, input_folder: str, target_fps: float, expected_files: set[str], is_real: bool
 ) -> str:
@@ -266,6 +320,7 @@ def ensure_binary_mask_structure(
   )
   print(f"Binary masks for {'real' if is_real else 'generated'} videos are ready at {binary_mask_folder}.")
   return binary_mask_folder
+
 
 if __name__ == "__main__":
 
@@ -318,8 +373,10 @@ if __name__ == "__main__":
     )
 
     # Generate binary masks for generated videos
+    validate_generations(input_folder=input_folder)
+    rename_generated_videos(generated_video_directory=input_folder, real_video_directory=real_video_folder)
     expected_generated_files = validate_video_files(input_folder, args.descriptions_file, '', int(fps), include_take_2=False)
-    #expected_generated_files = [f.replace("", "video-masks") for f in expected_real_files]
+
     binary_mask_generated_folder = ensure_binary_mask_structure(
       output_folder=args.output_folder,
       input_folder=input_folder,
@@ -337,7 +394,6 @@ if __name__ == "__main__":
     if is_csv_complete(csv_file_path, expected_real_scenarios):
       print(f"Skipping calculations for {csv_file_path} as it is already complete.")
     else:
-
       process_videos(
         real_folders=real_video_folder,
         generated_folders=input_folder,


### PR DESCRIPTION
Enables naming generated videos however one may wish to name them, as long as the videos start with the unique ID (e.g. 0001) and end with .mp4.

This PR also includes a few minor cosmetic changes, and enforces that generated videos are exactly 5 seconds long to avoid errors.