### PR TITLE
docs: fix parameter descriptions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ physics-IQ-benchmark/
 python3 code/run_physics_iq.py --input_folders <generated_videos_dirs> --output_folder <output_dir> --descriptions_file <descriptions_file>
 ```
 **Parameters:**
-- `--input_folders: The path to the directories containing input videos (in `.mp4` format), with one directory per model (/model_name/video.mp4)
-- `--output_folder`: The path to the directory where output csv files will be saved
-- `--descriptions_file`: The path to the descriptions.csv file
+- `--input_folders`: The path to the directories containing input videos (in `.mp4` format), with one directory per model (e.g., `/model_name/video.mp4`).
+- `--output_folder`: The path to the directory where output CSV files will be saved.
+- `--descriptions_file`: The path to the `descriptions.csv` file.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ physics-IQ-benchmark/
 python3 code/run_physics_iq.py --input_folders <generated_videos_dirs> --output_folder <output_dir> --descriptions_file <descriptions_file>
 ```
 **Parameters:**
-- `--input_folders`: The path to the directories containing input videos (in `.mp4` format), with one directory per model (e.g., `/model_name/video.mp4`).
+- `--input_folders`: The path to the directories containing input videos (in `.mp4` format), with one directory per model (`/model_name/video.mp4`).
 - `--output_folder`: The path to the directory where output CSV files will be saved.
 - `--descriptions_file`: The path to the `descriptions.csv` file.
 


### PR DESCRIPTION
While reading the README, I have found a few punctuation errors.
