### PR TITLE
Add Magi-1 model score

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,16 +37,17 @@ If you test your model on Physics-IQ and would like your score/paper/model to be
 
 | **#** | **Model** | **input type** | **Physics-IQ score** |
 | -- | --- | --- | --- |
-| 0 | [Magi-1](https://github.com/SandAI-org/MAGI-1)| multiframe (v2v) | **56.0 %**  |
-| 1 | [VideoPoet](https://arxiv.org/abs/2312.14125)                          | multiframe (v2v) | **29.5 %** :1st_place_medal: |
-| 2 | [Lumiere](https://arxiv.org/abs/2401.12945)                            | multiframe (v2v) | 23.0 % :2nd_place_medal: |
-| 3 | [Runway Gen 3](https://runwayml.com/research/introducing-gen-3-alpha)  | i2v        | 22.8 % :3rd_place_medal: |
-| 4 | [VideoPoet](https://arxiv.org/abs/2312.14125)                          | i2v        | 20.3 % |
-| 5 | [Lumiere](https://arxiv.org/abs/2401.12945)                            | i2v        | 19.0 % |
-| 6 | [Stable Video Diffusion](https://arxiv.org/abs/2311.15127)             | i2v        | 14.8 % |
-| 7 | [Pika](https://pika.art/)                                              | i2v        |  13.0 % |
-| 8 | [Sora](https://openai.com/sora/)                                       | i2v        |  10.0 % |
-*Note to early adopters of the benchmark: These results were finalized on February 19, 2025; if you used the toolbox before please re-run since we changed and improved a few aspects. Likewise, if you downloaded the dataset before that date, it is recommended to re-download it, ensuring the ground truth video masks have a duration of five seconds.*
+| 1 | [Magi-1](https://github.com/SandAI-org/MAGI-1)                         | multiframe (v2v) | **56.0 %** :1st_place_medal: |
+| 2 | [Magi-1](https://github.com/SandAI-org/MAGI-1)                         | i2v              | 30.2 % :2nd_place_medal: |
+| 3 | [VideoPoet](https://arxiv.org/abs/2312.14125)                          | multiframe (v2v) | 29.5 % :3rd_place_medal: |
+| 4 | [Lumiere](https://arxiv.org/abs/2401.12945)                            | multiframe (v2v) | 23.0 % |
+| 5 | [Runway Gen 3](https://runwayml.com/research/introducing-gen-3-alpha)  | i2v        | 22.8 %  |
+| 6 | [VideoPoet](https://arxiv.org/abs/2312.14125)                          | i2v        | 20.3 % |
+| 7 | [Lumiere](https://arxiv.org/abs/2401.12945)                            | i2v        | 19.0 % |
+| 8 | [Stable Video Diffusion](https://arxiv.org/abs/2311.15127)             | i2v        | 14.8 % |
+| 9 | [Pika](https://pika.art/)                                              | i2v        |  13.0 % |
+|10 | [Sora](https://openai.com/sora/)                                       | i2v        |  10.0 % |
+*Note to early adopters of the benchmark: results from the paper were finalized on February 19, 2025; if you used the toolbox before please re-run since we changed and improved a few aspects. Likewise, if you downloaded the dataset before that date, it is recommended to re-download it, ensuring the ground truth video masks have a duration of five seconds.*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ If you test your model on Physics-IQ and would like your score/paper/model to be
 
 | **#** | **Model** | **input type** | **Physics-IQ score** |
 | -- | --- | --- | --- |
+| 0 | [Magi-1](https://github.com/SandAI-org/MAGI-1)| multiframe (v2v) | **56.0 %**  |
 | 1 | [VideoPoet](https://arxiv.org/abs/2312.14125)                          | multiframe (v2v) | **29.5 %** :1st_place_medal: |
 | 2 | [Lumiere](https://arxiv.org/abs/2401.12945)                            | multiframe (v2v) | 23.0 % :2nd_place_medal: |
 | 3 | [Runway Gen 3](https://runwayml.com/research/introducing-gen-3-alpha)  | i2v        | 22.8 % :3rd_place_medal: |
@@ -45,7 +46,6 @@ If you test your model on Physics-IQ and would like your score/paper/model to be
 | 6 | [Stable Video Diffusion](https://arxiv.org/abs/2311.15127)             | i2v        | 14.8 % |
 | 7 | [Pika](https://pika.art/)                                              | i2v        |  13.0 % |
 | 8 | [Sora](https://openai.com/sora/)                                       | i2v        |  10.0 % |
-
 *Note to early adopters of the benchmark: These results were finalized on February 19, 2025; if you used the toolbox before please re-run since we changed and improved a few aspects. Likewise, if you downloaded the dataset before that date, it is recommended to re-download it, ensuring the ground truth video masks have a duration of five seconds.*
 
 ---


### PR DESCRIPTION
The recent open-source model, Magi-1, shares its Physics-IQ-Score which reached 56%. Here is the [link](https://github.com/SandAI-org/MAGI-1). 

![20250421-213610](https://github.com/user-attachments/assets/76c6bcc2-bdb0-4dba-8afc-ffb1d17d8b11)

This pull request add the score.