### PR TITLE
Add explicit checks for external tool dependencies (ffprobe, gsutil)

### DIFF
--- a/code/download_physics_iq_data.py
+++ b/code/download_physics_iq_data.py
@@ -16,8 +16,18 @@
 import os
 import subprocess
 import multiprocessing
+import shutil
 
 multiprocessing.set_start_method("spawn", force=True)
+
+def require_executable(name: str, install_hint: str):
+    path = shutil.which(name)
+    if path is None:
+        raise RuntimeError(
+            f"Required executable '{name}' not found in PATH.\n"
+            f"Install hint: {install_hint}"
+        )
+    return path
 
 
 def download_directory(remote_path: str, local_path: str):
@@ -29,8 +39,13 @@ def download_directory(remote_path: str, local_path: str):
     """
     print(f"Syncing {remote_path} → {local_path} using gsutil rsync...")
     os.makedirs(local_path, exist_ok=True) 
+    gsutil_path = require_executable(
+    "gsutil",
+    "Install via `pip install gsutil` or use system gsutil"
+    )
     try:
-        subprocess.run(["gsutil", "-m", "rsync", "-r", remote_path, local_path], check=True)
+        #
+        subprocess.run(["gsutil_path", "-m", "rsync", "-r", remote_path, local_path], check=True)
         print(f"Sync complete for {remote_path}.")
     except subprocess.CalledProcessError as e:
         print(f"Failed to sync: {remote_path}. Error: {e}")

--- a/code/run_physics_iq.py
+++ b/code/run_physics_iq.py
@@ -20,11 +20,22 @@ import cv2
 import argparse
 import subprocess
 import math
+import shutil
 
 from fps_changer import change_video_fps
 from calculate_and_write_metrics_to_csv import process_videos
 from calculate_iq_score import process_directory
 from binary_mask_generator import generate_binary_masks
+
+
+def require_executable(name: str, install_hint: str):
+    path = shutil.which(name)
+    if path is None:
+        raise RuntimeError(
+            f"Required executable '{name}' not found in PATH.\n"
+            f"Install hint: {install_hint}"
+        )
+    return path
 
 
 def is_csv_complete(csv_file_path: str, expected_scenarios: set[str]) -> bool:
@@ -134,8 +145,12 @@ def validate_folder_files_exist(
 
 def get_video_duration(video_path):
     """Return the duration of a video in seconds using ffprobe."""
+    ffprobe_path = require_executable(
+        "ffprobe",
+        "Install via `conda install -c conda-forge ffmpeg` or system ffmpeg"
+    )
     result = subprocess.run(
-            ["ffprobe", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", video_path],
+            ["ffprobe_path", "-v", "error", "-show_entries", "format=duration", "-of", "default=noprint_wrappers=1:nokey=1", video_path],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )


### PR DESCRIPTION
solves issue #31 

This PR improves the robustness of the Physics-IQ benchmark by adding explicit validation for required external executables (ffprobe, gsutil) before they are invoked at runtime.

Currently, missing or PATH-inaccessible tools cause hard failures (e.g. FileNotFoundError) that are difficult to debug, particularly in non-root or managed environments. This change surfaces clear, actionable error messages instead.