### PR TITLE
Add Sora2 and Wan2.2 leaderboard rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,22 @@ If you test your model on Physics-IQ and would like your score/paper/model to be
 | -- | --- | --- | --- | --- |
 | 1 | [Magi-1 + VJEPA-2 BoN sampling](https://arxiv.org/abs/2601.10553)              | multiframe (v2v) | **62.6 %** :1st_place_medal:  | 2025-10-28 |
 | 2 | [Magi-1](https://arxiv.org/abs/2505.13211)                                     | multiframe (v2v) | **56.0 %** :2nd_place_medal:  | 2025-04-21 |
-| 3 | [Magi-1 + VJEPA-2 BoN sampling](https://arxiv.org/abs/2601.10553)              | i2v              | **36.9 %** :3rd_place_medal:  | 2025-10-28 |
-| 4 | [Video-GPT](https://arxiv.org/abs/2505.12489)                                  | multiframe (v2v) | 35.0 %  | 2025-05-22 |
-| 5 | [CogVideoX-5b](https://github.com/ved015/CogVideoX-5b-Physics_iq_benchmarking) | i2v              | 32.3 %  | 2026-01-06 |
-| 6 | [Magi-1](https://arxiv.org/abs/2505.13211)                                     | i2v              | 30.2 %  | 2025-04-21 |
-| 7 | [VideoPoet](https://arxiv.org/abs/2312.14125)                                  | multiframe (v2v) | 29.5 %  | 2025-02-19 |
-| 8 | [Lumiere](https://arxiv.org/abs/2401.12945)                                    | multiframe (v2v) | 23.0 %  | 2025-02-19 |
-| 9 | [Runway Gen 3](https://runwayml.com/research/introducing-gen-3-alpha)          | i2v              | 22.8 %  | 2025-02-19 |
-| 10| [VideoPoet](https://arxiv.org/abs/2312.14125)                                  | i2v              | 20.3 %  | 2025-02-19 |
-| 11| [Lumiere](https://arxiv.org/abs/2401.12945)                                    | i2v              | 19.0 %  | 2025-02-19 |
-| 12| [Stable Video Diffusion](https://arxiv.org/abs/2311.15127)                     | i2v              | 14.8 %  | 2025-02-19 |
-| 13| [Pika](https://pika.art/)                                                      | i2v              |  13.0 % | 2025-02-19 |
-| 14| [Sora](https://openai.com/sora/)                                               | i2v              |  10.0 % | 2025-02-19 |
+| 3 | [Sora2 + WMReward (BoN)](https://arxiv.org/abs/2601.10553)                     | i2v              | **46.4 %** :3rd_place_medal:  | 2026-04-01 |
+| 4 | [Wan2.2 + WMReward (BoN)](https://arxiv.org/abs/2601.10553)                    | i2v              | 44.4 %  | 2026-04-01 |
+| 5 | [Sora2](https://openai.com/index/sora-2/)                                      | i2v              | 42.3 %  | 2026-04-01 |
+| 6 | [Wan2.2](https://github.com/Wan-Video/Wan2.2)                                 | i2v              | 38.3 %  | 2026-04-01 |
+| 7 | [Magi-1 + VJEPA-2 BoN sampling](https://arxiv.org/abs/2601.10553)             | i2v              | 36.9 %  | 2025-10-28 |
+| 8 | [Video-GPT](https://arxiv.org/abs/2505.12489)                                 | multiframe (v2v) | 35.0 %  | 2025-05-22 |
+| 9 | [CogVideoX-5b](https://github.com/ved015/CogVideoX-5b-Physics_iq_benchmarking) | i2v              | 32.3 %  | 2026-01-06 |
+| 10 | [Magi-1](https://arxiv.org/abs/2505.13211)                                    | i2v              | 30.2 %  | 2025-04-21 |
+| 11 | [VideoPoet](https://arxiv.org/abs/2312.14125)                                 | multiframe (v2v) | 29.5 %  | 2025-02-19 |
+| 12 | [Lumiere](https://arxiv.org/abs/2401.12945)                                   | multiframe (v2v) | 23.0 %  | 2025-02-19 |
+| 13 | [Runway Gen 3](https://runwayml.com/research/introducing-gen-3-alpha)         | i2v              | 22.8 %  | 2025-02-19 |
+| 14 | [VideoPoet](https://arxiv.org/abs/2312.14125)                                 | i2v              | 20.3 %  | 2025-02-19 |
+| 15 | [Lumiere](https://arxiv.org/abs/2401.12945)                                   | i2v              | 19.0 %  | 2025-02-19 |
+| 16 | [Stable Video Diffusion](https://arxiv.org/abs/2311.15127)                    | i2v              | 14.8 %  | 2025-02-19 |
+| 17 | [Pika](https://pika.art/)                                                     | i2v              | 13.0 %  | 2025-02-19 |
+| 18 | [Sora](https://openai.com/sora/)                                              | i2v              | 10.0 %  | 2025-02-19 |
 
 *Note to early adopters of the benchmark: results from the paper were finalized on February 19, 2025; if you used the toolbox before please re-run since we changed and improved a few aspects. Likewise, if you downloaded the dataset before that date, it is recommended to re-download it, ensuring the ground truth video masks have a duration of five seconds.*
 


### PR DESCRIPTION
## Summary

This PR adds the Physics-IQ results for Sora 2 and Wan2.2, together with the corresponding WMReward-enhanced results reported in WMReward.

All four entries are single-frame conditioned (`i2v`) results.

## Added leaderboard rows

```md
| 3 | [Sora2 + WMReward (BoN)](https://arxiv.org/abs/2601.10553) | i2v | **46.4 %** :3rd_place_medal: | 2026-04-01 |
| 4 | [Wan2.2 + WMReward (BoN)](https://arxiv.org/abs/2601.10553) | i2v | 44.4 % | 2026-04-01 |
| 5 | [Sora2](https://openai.com/index/sora-2/) | i2v | 42.3 % | 2026-04-01 |
| 6 | [Wan2.2](https://github.com/Wan-Video/Wan2.2) | i2v | 38.3 % | 2026-04-01 |
