### PR TITLE
New GeoPhys results on the Physics-IQ Verified Leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 
 | # | Model | input type | Physics-IQ verified | date added (YYYY-MM-DD) |
 |---|---|---|---|---|
-| 1 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/)| multiframe (v2v) | **58.2** <small>± 1.8</small> <br> 🥇 v2v | 2026-06-19 |
-| 2 | Magi-1 24B | multiframe (v2v) | 48.4 <small>± 1.1</small> | 2026-06-19 |
+| 1 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | multiframe (v2v) | **58.2** <br> 🥇 v2v | 2026-06-19 |
+| 2 | Magi-1 24B <small>(op)</small> | multiframe (v2v) | 48.4 <small>± 1.1</small> | 2026-06-19 |
 | 3 | Cosmos3-Super-Image2Video | i2v | **39.5** <small>± 0.8</small> <br> 🥇 i2v | 2026-06-18 |
 | 4 | Grok Imagine Video | i2v | **34.8** <small>± 0.6</small> <br> 🥈 i2v | 2026-06-17 |
-| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) | i2v | **33.7** <small>± 1.4</small>  <br> 🥉 i2v| 2026-06-19 |
+| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | i2v | **33.7** <br> 🥉 i2v | 2026-06-19 |
 | 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> | 2026-06-17 |
 | 7 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
 | 8 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
-| 9 | Magi-1 24B| i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
+| 9 | Magi-1 24B <small>(op)</small> | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
 | 10 | Sora 2 | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
 | 11 | P-Video | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,17 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 
 | # | Model | input type | Physics-IQ verified | date added (YYYY-MM-DD) |
 |---|---|---|---|---|
-| 1 | Cosmos3-Super-Image2Video | i2v | **39.5** <small>± 0.8</small> <br> 🥇 i2v | 2026-06-18 |
-| 2 | Grok Imagine Video | i2v | **34.8** <small>± 0.6</small> <br> 🥈 i2v | 2026-06-17 |
-| 3 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> <br> 🥉 i2v | 2026-06-17 |
-| 4 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
-| 5 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
-| 6 | Sora 2 | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
-| 7 | P-Video | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
+| 1 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/)| multiframe (v2v) | **58.2** <small>± 1.8</small> <br> 🥇 v2v | 2026-06-19 |
+| 2 | Magi-1 24B | multiframe (v2v) | 48.4 <small>± 1.1</small> | 2026-06-19 |
+| 3 | Cosmos3-Super-Image2Video | i2v | **39.5** <small>± 0.8</small> <br> 🥇 i2v | 2026-06-18 |
+| 4 | Grok Imagine Video | i2v | **34.8** <small>± 0.6</small> <br> 🥈 i2v | 2026-06-17 |
+| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) | i2v | **33.7** <small>± 1.4</small> | 2026-06-19 |
+| 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> <br> 🥉 i2v | 2026-06-17 |
+| 7 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
+| 8 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
+| 9 | Magi-1 24B| i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
+| 10 | Sora 2 | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
+| 11 | P-Video | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
 
 For details on the Physics-IQ Verified metrics, see the [arXiv report](https://arxiv.org/abs/2606.18943).
 

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 
 | # | Model | input type | Physics-IQ verified | date added (YYYY-MM-DD) |
 |---|---|---|---|---|
-| 1 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | multiframe (v2v) | **58.2** <br> 🥇 v2v | 2026-06-19 |
-| 2 | Magi-1 24B <small>(op)</small> | multiframe (v2v) | 48.4 <small>± 1.1</small> | 2026-06-19 |
+| 1 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | multiframe (v2v) | **58.2** <small>± 1.8</small> <br> 🥇 v2v | 2026-06-19 |
+| 2 | Magi-1 24B <small>(op)</small> | multiframe (v2v) | **48.4** <small>± 1.1</small>  <br> 🥈 v2v| 2026-06-19 |
 | 3 | Cosmos3-Super-Image2Video | i2v | **39.5** <small>± 0.8</small> <br> 🥇 i2v | 2026-06-18 |
 | 4 | Grok Imagine Video | i2v | **34.8** <small>± 0.6</small> <br> 🥈 i2v | 2026-06-17 |
-| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | i2v | **33.7** <br> 🥉 i2v | 2026-06-19 |
+| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | i2v | **33.7** <small>± 1.4</small> <br> 🥉 i2v | 2026-06-19 |
 | 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> | 2026-06-17 |
 | 7 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
 | 8 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 | 2 | Magi-1 24B | multiframe (v2v) | 48.4 <small>± 1.1</small> | 2026-06-19 |
 | 3 | Cosmos3-Super-Image2Video | i2v | **39.5** <small>± 0.8</small> <br> 🥇 i2v | 2026-06-18 |
 | 4 | Grok Imagine Video | i2v | **34.8** <small>± 0.6</small> <br> 🥈 i2v | 2026-06-17 |
-| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) | i2v | **33.7** <small>± 1.4</small> | 2026-06-19 |
-| 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> <br> 🥉 i2v | 2026-06-17 |
+| 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) | i2v | **33.7** <small>± 1.4</small>  <br> 🥉 i2v| 2026-06-19 |
+| 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> | 2026-06-17 |
 | 7 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
 | 8 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
 | 9 | Magi-1 24B| i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |


### PR DESCRIPTION
We re-tested the GeoPhys best-of-N verifier on Physics-IQ Verified. N=16 candidates (seeds) for Magi-1 24B, both i2v and v2v.

Prompts: all rows use original prompts (op), not bpp.

Error bars:  Magi-1 24B, no verifier, std across 16 generation seeds (across-run, like your 4-run protocol).

GeoPhys is a single deterministic selection (no seed variance from the verifier side). We report the std of the per-scenario verified score across the 198 scenarios, divided by √198.