### PR TITLE
Add Kandinsky-WM 1.0 Physics-IQ Verified result

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 | 5 | [Magi-1 24B + GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> | i2v | **33.7** <small>± 1.4</small> <br> 🥉 i2v | 2026-06-19 |
 | 6 | Hunyuan Video 1.5 | i2v | **33.4** <small>± 0.8</small> | 2026-06-17 |
 | 7 | Wan 2.2 | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
-| 8 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
-| 9 | Magi-1 24B <small>(op)</small> | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
-| 10 | Sora 2 | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
-| 11 | P-Video | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
+| 8 | [Kandinsky-WM 1.0](https://huggingface.co/kandinskylab/Kandinsky-WM-1.0-I2V-5s-PH) | i2v | 30.8 <small>± 0.9</small> | 2026-08-04 |
+| 9 | Cosmos3-Nano | i2v | 30.3 <small>± 0.6</small> | 2026-06-18 |
+| 10 | Magi-1 24B <small>(op)</small> | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
+| 11 | Sora 2 | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
+| 12 | P-Video | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
 
 For details on the Physics-IQ Verified metrics, see the [arXiv report](https://arxiv.org/abs/2606.18943).
 


### PR DESCRIPTION
## Summary

Adds the Physics-IQ Verified leaderboard entry for Kandinsky-WM 1.0.

- Model checkpoint: https://huggingface.co/kandinskylab/Kandinsky-WM-1.0-I2V-5s-PH
- Input type: I2V
- Prompt setting: BPP with a static-camera constraint and Qwen3-VL temporal prompt expansion
- Result: **30.8 +/- 0.9** (mean +/- sample standard deviation across four runs)

## Reproduction artifacts

The complete generated-video artifacts are available at:
https://huggingface.co/datasets/Messimm/Kandinsky-WM-1.0-Physics-IQ-Verified

The dataset contains the generated videos for seeds 32768, 1109, 1137, and 16384; their generated masks; detailed per-scene result CSVs; metrics JSONs; evaluation logs; and every prompt-pipeline stage from BPP to the final generation and take-1 evaluation CSVs.

The artifact README describes the relationship between the released code, checkpoint, prompt pipeline, and evaluation outputs.
