### PR TITLE
Add recent Physics-IQ Verified leaderboard entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,20 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 | 1 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) + [GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | multiframe (v2v) | **58.2** <small>± 1.8</small> <br> 🥇 v2v | 2026-06-19 |
 | 2 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | multiframe (v2v) | **48.4** <small>± 1.1</small>  <br> 🥈 v2v| 2026-06-19 |
 | 3 | [Cosmos3-Super-Image2Video](https://huggingface.co/nvidia/Cosmos3-Super-Image2Video) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/75) | i2v | **42.7** <small>± 0.8</small> <br> 🥇 i2v | 2026-09-04 |
-| 4 | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/75) | i2v | **37.3** <small>± 0.9</small> <br> 🥈 i2v | 2026-09-04 |
-| 5 | [Grok Imagine Video](https://x.ai/news/grok-imagine-api) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 34.8 <small>± 0.6</small> <br> 🥉 i2v | 2026-06-17 |
-| 6 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) + [GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 33.7 <small>± 1.4</small> | 2026-06-19 |
-| 7 | [Hunyuan Video 1.5](https://arxiv.org/abs/2511.18870) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 33.4 <small>± 0.8</small> | 2026-06-17 |
-| 8 | [Cosmos3-Edge](https://huggingface.co/nvidia/Cosmos3-Edge) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/76) | i2v | 32.7 <small>± 1.1</small> | 2026-08-31 |
-| 9 | [Wan 2.2](https://github.com/Wan-Video/Wan2.2) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
-| 10 | [Kandinsky-WM 1.0](https://huggingface.co/kandinskylab/Kandinsky-WM-1.0-I2V-5s-PH) reported [here](https://huggingface.co/datasets/Messimm/Kandinsky-WM-1.0-Physics-IQ-Verified) | i2v | 30.8 <small>± 0.9</small> | 2026-08-04 |
-| 11 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
-| 12 | [Sora 2](https://openai.com/index/sora-2/) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
-| 13 | [P-Video](https://www.pruna.ai/p-video) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
+| 4 | [MiniMax H3](https://huggingface.co/MiniMaxAI/MiniMax-H3) <small>(FL2VA)</small> reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/pull/80) | i2v | **39.8** <small>± 0.4</small> <br> 🥈 i2v | 2026-08-24 |
+| 5 | [Cosmos3-Nano](https://huggingface.co/nvidia/Cosmos3-Nano) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/75) | i2v | **37.3** <small>± 0.9</small> <br> 🥉 i2v | 2026-09-04 |
+| 6 | [MiniMax H3 Max](https://fal.ai/models/minimax/h3-max/image-to-video) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/pull/80) | i2v | 36.2 <small>± 0.7</small> | 2026-08-27 |
+| 7 | [Grok Imagine Video](https://x.ai/news/grok-imagine-api) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 34.8 <small>± 0.6</small> | 2026-06-17 |
+| 8 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) + [GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 33.7 <small>± 1.4</small> | 2026-06-19 |
+| 9 | [Hunyuan Video 1.5](https://arxiv.org/abs/2511.18870) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 33.4 <small>± 0.8</small> | 2026-06-17 |
+| 10 | [Cosmos3-Edge](https://huggingface.co/nvidia/Cosmos3-Edge) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/76) | i2v | 32.7 <small>± 1.1</small> | 2026-08-31 |
+| 11 | [Wan 2.2](https://github.com/Wan-Video/Wan2.2) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
+| 12 | [CogVideoX-5B](https://huggingface.co/zai-org/CogVideoX-5b-I2V) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/pull/80) | i2v | 31.8 <small>± 1.5</small> | 2026-08-18 |
+| 13 | [Kandinsky-WM 1.0](https://huggingface.co/kandinskylab/Kandinsky-WM-1.0-I2V-5s-PH) reported [here](https://huggingface.co/datasets/Messimm/Kandinsky-WM-1.0-Physics-IQ-Verified) | i2v | 30.8 <small>± 0.9</small> | 2026-08-04 |
+| 14 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |
+| 15 | [Wan 2.2 5B](https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/pull/80) | i2v | 27.7 <small>± 0.9</small> | 2026-08-18 |
+| 16 | [Sora 2](https://openai.com/index/sora-2/) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 26.5 <small>± 0.8</small> | 2026-06-17 |
+| 17 | [P-Video](https://www.pruna.ai/p-video) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 25.3 <small>± 1.8</small> | 2026-06-17 |
 
 For details on the Physics-IQ Verified metrics, see the [arXiv report](https://arxiv.org/abs/2606.18943).
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The leaderboard is also hosted at: [physics-iq-verified.anates.ai](https://physi
 | 8 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) + [GeoPhys (BoN)](https://christianinterno.github.io/GeoPhys/) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 33.7 <small>± 1.4</small> | 2026-06-19 |
 | 9 | [Hunyuan Video 1.5](https://arxiv.org/abs/2511.18870) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 33.4 <small>± 0.8</small> | 2026-06-17 |
 | 10 | [Cosmos3-Edge](https://huggingface.co/nvidia/Cosmos3-Edge) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/issues/76) | i2v | 32.7 <small>± 1.1</small> | 2026-08-31 |
-| 11 | [Wan 2.2](https://github.com/Wan-Video/Wan2.2) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
+| 11 | [Wan 2.2 14B](https://github.com/Wan-Video/Wan2.2) reported [here](https://arxiv.org/abs/2606.18943) | i2v | 32.2 <small>± 0.6</small> | 2026-06-17 |
 | 12 | [CogVideoX-5B](https://huggingface.co/zai-org/CogVideoX-5b-I2V) reported [here](https://github.com/google-deepmind/physics-IQ-benchmark/pull/80) | i2v | 31.8 <small>± 1.5</small> | 2026-08-18 |
 | 13 | [Kandinsky-WM 1.0](https://huggingface.co/kandinskylab/Kandinsky-WM-1.0-I2V-5s-PH) reported [here](https://huggingface.co/datasets/Messimm/Kandinsky-WM-1.0-Physics-IQ-Verified) | i2v | 30.8 <small>± 0.9</small> | 2026-08-04 |
 | 14 | [Magi-1 24B](https://arxiv.org/abs/2505.13211) <small>(op)</small> reported [here](https://christianinterno.github.io/GeoPhys/) | i2v | 30.2 <small>± 1.1</small> | 2026-06-19 |


### PR DESCRIPTION
Adds four I2V entries to the Physics-IQ Verified leaderboard and reorders the I2V rankings accordingly:
- MiniMax H3 (FL2VA): 39.8 ± 0.4
- MiniMax H3 Max: 36.2 ± 0.7
- CogVideoX-5B: 31.8 ± 1.5
- Wan 2.2 5B: 27.7 ± 0.9